### PR TITLE
 MPI process wait for Head actor to be ready before to start (simulat…

### DIFF
--- a/doreisa/window_api.py
+++ b/doreisa/window_api.py
@@ -51,7 +51,12 @@ def run_simulation(
     # Limit the advance the simulation can have over the analytics
     max_pending_arrays = 2 * len(arrays_description)
 
-    head: Any = SimulationHead.options(**get_head_actor_options()).remote(head_arrays_description, max_pending_arrays)
+    #    head: Any = SimulationHead.options(**get_head_actor_options()).remote(head_arrays_description, max_pending_arrays)
+    # Get or create head actor (can be created by simulation)
+    head: Any = SimulationHead.options(**get_head_actor_options()).remote()
+    # Properly initialize head actor and  unlock simulation processes waiting for it.  
+    head.init_by_analytics.remote(head_arrays_description, max_pending_arrays)
+    
 
     arrays_by_iteration: dict[int, dict[str, da.Array]] = {}
 


### PR DESCRIPTION
Doreisa fails if the MPI processes start calling the head actor  before the analytics starts  it.  Solution was so far to put some sleep, but this always fails at some point. This PR proposes a code change to avoid this issue. The head actor is created either by the simulation processes or the analytics, whoever starts first and then the mpi processes way for the proper initialization of the head actor by the simulation.  
Tested on a single node config only. 
Little uncertainty if the head actor is created on the expected  head node. That should be the case as stated by the Ray doc (https://docs.ray.io/en/latest/ray-core/api/doc/ray.runtime_context.get_runtime_context.html). But would need proper testing to be sure that when created by a MPI process the head actor does not run on this process node.  